### PR TITLE
Do not use trap for an error message regarding unknown command

### DIFF
--- a/ici
+++ b/ici
@@ -111,6 +111,14 @@ shift
 cmd="$1"
 shift
 
+dir="${ICI_LIB_DIR}/$cmd.d"
+
+if ! test -d "$dir"; then
+    echo "$self: unknown command '$cmd'" 1>&2
+    echo "Try 'ici --help' for more information." 1>&2
+    exit 1
+fi
+
 _trap ()
 {
    err=$?
@@ -125,16 +133,9 @@ _trap ()
    exit $err
 }
 
-dir="${ICI_LIB_DIR}/$cmd.d"
 cfg=`mktemp`
 log=`mktemp`
 trap '_trap $cfg $log' EXIT
-
-if ! test -d "$dir"; then
-    echo "$self: unknown command '$cmd'" 1>&2
-    echo "Try 'ici --help' for more information." 1>&2
-    exit 1
-fi
 
 parts=$(echo `find $dir/ -mindepth 1 -maxdepth 1 \
     -type f -o -type l -executable -name '[0-9]*' \! -name \*~ | sort`)


### PR DESCRIPTION
There's no reason whatsoever to have this kind of interaction:

```
$ ici blah foo
ici: unknown command 'foo'
Try 'ici --help' for more information.
--- cfg ---
--- out ---
```
