### PR TITLE
Add a missing shift

### DIFF
--- a/ici
+++ b/ici
@@ -148,7 +148,8 @@ export ICI_PKCS11_TOOL
 		listcmds
 		exit 0 ;;
 	    --debug | -d )
-		ICI_DEBUG=y ;;
+		ICI_DEBUG=y
+		shift ;;
 	    -- )
         # Stop option processing
 		shift


### PR DESCRIPTION
A missing shift when parsing the --debug option, which will lead to
an endless loop.
