### PR TITLE
Security fix: protect ca.config

### DIFF
--- a/init.d/02caconfig
+++ b/init.d/02caconfig
@@ -12,6 +12,7 @@ ICI_PUBLIC_URL=http://ca.example.com
 SOFTHSM_CONF=$ICI_CA_DIR/softhsm.conf
 export SOFTHSM_CONF
 EOC
+chmod 600 $ICI_CA_DIR/ca.config
 
 touch "${ICI_CA_DIR}/index.txt"
 


### PR DESCRIPTION
ca.config contains the secret pin for the PCKS#11 store, and therefore
needs protection from prying eyes.
