### PR TITLE
Fine-tune the installation permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,14 @@ mandir=${prefix}/share/man
 INSTALL=install
 INSTALL_EXE=$(INSTALL) -D --mode 755
 INSTALL_DATA=$(INSTALL) -D --mode 0644
-PRG_DIR=gencrl.d gentoken.d help.d init.d issue.d lib publish.d root.d revoke.d
+PRG_DIR=gencrl.d gentoken.d help.d init.d issue.d publish.d root.d revoke.d
+LIB_DIR=lib
 DATA_DIR=public_html
 
-PRG=$$(find $(PRG_DIR) -type f -o -type l)
-DATA=$$(find $(DATA_DIR) -type f)
+PRG=$$(find $(PRG_DIR) \( -type f -o -type l \) -executable \! -name '*~') \
+    $$(find $(LIB_DIR) -type f)
+DATA=$$(find $(PRG_DIR) \( -type f -o -type l \) \! -executable \! -name '*~') \
+     $$(find $(DATA_DIR) -type f)
 
 all: manpages
 
@@ -61,7 +64,7 @@ install: all
 		$(INSTALL_EXE) $$f $(DESTDIR)$(sharedir)/ici/$$f; \
 	done
 	for f in $(DATA); do \
-		$(INSTALL) -D $$f $(DESTDIR)/$(sharedir)/ici/$$f; \
+		$(INSTALL_DATA) -D $$f $(DESTDIR)/$(sharedir)/ici/$$f; \
 	done
 	cp -pr public_html $(DESTDIR)/$(sharedir)/ici/public_html
 	@[ -f $(DESTDIR)$(etcdir)/ici/ici.conf.dist.old ] && \


### PR DESCRIPTION
Data files shouldn't have exec perms, so use INSTALL_DATA for them
rather than just INSTALL (it sets x perms by default)

Also, since we now have data files ('desc' and 'help') in the program
directories, we need to be a bit more careful.  The easiest is to use
find's -executable, and then make sure they have x perms in the source
tree, which they need anyway to be able to test without installing.

Finally, avoid installing GNU backup files
