### PR TITLE
Update to OpenSSL1.1 and SoftHSM2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Git: git://github.com/leifj/ici.git
 
 Package: ici
 Architecture: all
-Depends: ${misc:Depends}, openssl, opensc, libengine-pkcs11-openssl
+Depends: ${misc:Depends}, openssl, opensc, libengine-pkcs11-openssl1.1
 Recommends: softhsm
 Description: the imbecile certificate issuer
  ici is a refactor of the CSP package with support for PKCS#11

--- a/gentoken.d/02softhsm
+++ b/gentoken.d/02softhsm
@@ -6,5 +6,5 @@ cat>$ICI_CA_DIR/softhsm.conf<<EOC
 0: $ICI_CA_DIR/softhsm.db
 EOC
 
-softhsm --slot "${ICI_CA_KEY_SLOT}" --label "${ICI_CA}_key" \
+softhsm2-util --slot "${ICI_CA_KEY_SLOT}" --label "${ICI_CA}_key" \
    --init-token --pin "${ICI_PKCS11_PIN}" --so-pin "${ICI_PKCS11_PIN}"

--- a/init.d/02caconfig
+++ b/init.d/02caconfig
@@ -3,7 +3,7 @@
 cat>$ICI_CA_DIR/ca.config<<EOC
 ICI_CA_KEY_ID=a1a2
 ICI_CA_KEY_SLOT=0
-ICI_PKCS11=/usr/lib/softhsm/libsofthsm.so
+ICI_PKCS11=/usr/lib/softhsm/libsofthsm2.so
 ICI_PKCS11_PIN=secret
 ICI_MD=sha256
 ICI_PUBLIC_URL=http://ca.example.com

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -5,17 +5,11 @@ cat<<EOC
 openssl_conf = openssl_init
 [openssl_init]
 engines = engines_section
-oid_section = oids
-
-[oids]
-domainComponent=0.9.2342.19200300.100.1.25
-
 [engines_section]
 pkcs11 = pkcs11_section
 
 [pkcs11_section]
 engine_id = pkcs11
-dynamic_path = /usr/lib/engines/engine_pkcs11.so
 MODULE_PATH = ${ICI_PKCS11}
 PIN = ${ICI_PKCS11_PIN}
 init = 0


### PR DESCRIPTION
This PR is made to get ICI working with OpenSSL1.1 and SoftHSM2 from Ubuntu Bionic