### PR TITLE
Use token instead of slot

### DIFF
--- a/gencrl.d/90openssl
+++ b/gencrl.d/90openssl
@@ -4,14 +4,6 @@
 
 mkdir -p $ICI_CA_DIR/certs
 
-if [ -z "${ICI_CRL_KEY_SLOT}" ]; then
-   ICI_CRL_KEY_SLOT="${ICI_CA_KEY_SLOT}"
-fi
-
-if [ -z "${ICI_CRL_KEY_ID}" ]; then
-   ICI_CRL_KEY_ID="${ICI_CA_KEY_ID}"
-fi
-
 $ICI_OPENSSL ca -gencrl -notext -batch \
    -config $ICI_CONFIG -engine pkcs11 -crlexts crl_extensions \
    -keyfile "pkcs11:token=${ICI_CA}_key" -keyform engine \

--- a/gencrl.d/90openssl
+++ b/gencrl.d/90openssl
@@ -14,5 +14,5 @@ fi
 
 $ICI_OPENSSL ca -gencrl -notext -batch \
    -config $ICI_CONFIG -engine pkcs11 -crlexts crl_extensions \
-   -keyfile "${ICI_CRL_KEY_SLOT}:${ICI_CRL_KEY_ID}" -keyform engine \
+   -keyfile "pkcs11:token=${ICI_CA}_key" -keyform engine \
    -crldays ${ICI_DAYS} -out "${ICI_CA_DIR}/crl.pem"

--- a/issue.d/90openssl
+++ b/issue.d/90openssl
@@ -15,7 +15,7 @@ fi
 cat /dev/urandom | tr -cd 'a-f0-9' | head -c 16 > $ICI_CA_DIR/serial
 $ICI_OPENSSL ca -notext -batch $nameopt \
    -config $ICI_CONFIG -engine pkcs11 -extensions extensions \
-   -keyfile "${ICI_CA_KEY_SLOT}:${ICI_CA_KEY_ID}" -keyform engine \
+   -keyfile "pkcs11:token=${ICI_CA}_key" -keyform engine \
    -days ${ICI_DAYS} -outdir $ICI_CA_DIR/certs -in "$csr"
 }
 

--- a/root.d/02keygen
+++ b/root.d/02keygen
@@ -3,4 +3,4 @@
 . $ICI_CA_DIR/ca.config
 
 $ICI_PKCS11_TOOL --module=$ICI_PKCS11 -l --keypairgen --pin ${ICI_PKCS11_PIN} \
-  --key-type rsa:${ICI_BITS:-4096} --slot ${ICI_CA_KEY_SLOT} --id ${ICI_CA_KEY_ID}
+  --key-type rsa:${ICI_BITS:-4096} --token-label ${ICI_CA}_key --id ${ICI_CA_KEY_ID}

--- a/root.d/90openssl
+++ b/root.d/90openssl
@@ -4,5 +4,5 @@
 
 $ICI_OPENSSL req -new -x509 \
    -config $ICI_CONFIG -engine pkcs11 -extensions extensions \
-   -key "${ICI_CA_KEY_SLOT}:${ICI_CA_KEY_ID}" -keyform engine \
+   -key "pkcs11:token=${ICI_CA}_key" -keyform engine \
    -days ${ICI_DAYS:-3650} -set_serial 0 -out $ICI_CA_DIR/ca.crt


### PR DESCRIPTION
In SoftHSM2 slots aren't persistent [SoftHSM2 PR#199](https://github.com/opendnssec/SoftHSMv2/pull/199) but label/token is, using the PKCS11-URI Schema specified in [RFC7512](https://tools.ietf.org/html/rfc7512).